### PR TITLE
Adding new script: cv_diff.rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,73 @@ rake katello:sync_capsule_selective
         If you select a CONTENT_VIEW and LIFECYCLE_ENVIRONMENT, but the former is not in the latter, then nothing
           will be synchronized to the target Capsule.
 ~~~
+
+### cv_diff.rake
+Calculate content differences between two given Content View versions. The script can currently compare RPM, Repositories, or Errata.
+
+
+#### Usage
+~~~
+# foreman-rake katello:cv_diff LEFT="RHEL 7 frontend:21.0" RIGHT=18.0 WHAT=errata
+# foreman-rake katello:cv_diff LEFT="RHEL 7 frontend" 
+# foreman-rake katello:cv_diff LEFT="RHEL 7 frontend" RIGHT=some_ccv:8.0 WHAT=repo
+~~~
+
+The `LEFT` and `RIGHT` parameters can be either a CV name or label or numeric ID, optionally followed by `:x.y` representing *major.minor* version.
+If version numbers are omitted, latest CV version is used.
+If `RIGHT` is only a version number, the same CV from LEFT will be used.
+If `RIGHT` is omitted altogether, the same CV from LEFT will be used and in its latest version.
+
+#### More information
+~~~
+# foreman-rake -D katello:cv_diff
+rake katello:cv_diff
+    Calculates and shows the difference (in terms of package contents) between two versions of the same Content View.
+    
+      Parameters:
+    
+          * LEFT=CV:version  : Content View and version identifiers.
+                             : CV can be either a name or label or numerical ID of a Content View.
+                             : Omitting the version is the same as specifying the latest version of this Content View.
+                             : Version is specified as major.minor. See examples below.
+                             : Examples:
+                             :   LEFT="This nice CV"  -- latest version of a Content View named "This nice CV"
+                             :   LEFT="this_nice_cv"  -- latest version of a Content View named or labeled "this_nice_cv"
+                             :   LEFT="This nice CV:15.0"  -- version 15.0 of "This nice CV"
+                             :   LEFT="this_nice_cv:15.0"  -- version 15.0 of "this_nice_cv"
+                             :   LEFT="45"       -- latest version of Content View ID 45
+                             :   LEFT="45:15.0"  -- version 15.0 of Content View ID 45
+    
+          * RIGHT=CV:version  : Content View and version identifiers.
+                              : Same conditions as LEFT, with a single exception:
+                              :   RIGHT=version (i.e. omitting the CV) will consider it to be the same Content View as LEFT.
+                              :   Omitting the RIGHT argument altogether will consider this to be the second-latest version of LEFT.
+                              : Examples:
+                              :   RIGHT="Other nice CV"  -- will compare LEFT to the latest version of "Other nice CV"
+                              :   RIGHT="other_nice_cv"  -- will compare LEFT to the latest version of "other_nice_cv"
+                              :   RIGHT="Other nice CV:31.0"  -- will compare LEFT to version 31.0 of "Other nice CV"
+                              :   RIGHT="other_nice_cv:31.0"  -- will compare LEFT to version 31.0 of "other_nice_cv"
+                              :   RIGHT="67"  -- will compare LEFT to the latest version of Content View ID 67
+                              :   RIGHT="45:31.0"  -- will compare LEFT to version 31.0 of Content View ID 67
+                              :   <RIGHT is omitted>  -- will compare LEFT to the second-latest version of LEFT
+    
+    
+        Global paramenter:
+    
+        * VERBOSE               : true/false Print verbose information.
+        * WHAT                  : What to diff. Value is one of [ rpm, repo, errata ]
+    
+      Examples:
+        * rake katello:cv_diff LEFT="This nice CV:15.0"
+            (will diff version 15.0 and the latest version of "This nice CV")
+    
+        * rake katello:cv_diff LEFT="this_nice_cv" RIGHT="Other CV"
+            (will diff the latest version of "this_nice_cv" to the latest version of "Other CV".)
+    
+        * rake katello:cv_diff LEFT=14
+            (will diff the two latest versions of CV ID 14.)
+    
+        * rake katello:cv_diff LEFT="some cv:3.2" RIGHT="another cv:5.1"
+            (will diff version 3.2 of "some cv" to version 5.1 of "another cv")
+~~~
+

--- a/cv_diff.rake
+++ b/cv_diff.rake
@@ -1,0 +1,103 @@
+namespace :katello do
+  desc <<-DESC.strip_heredoc
+    Calculates and shows the difference (in terms of package contents) between two versions of the same Content View.
+
+      Required parameters:
+        * CONTENT_VIEW          : name or label or numeric ID of the Content View to examine
+
+      Optional:
+        * VERSION1              : CV version number (e.g. 14.0) or numeric ID (e.g. 523) of the first CV version to compare
+        * VERSION2              : CV version number (e.g. 14.0) or numeric ID (e.g. 523) of the second CV version to compare
+
+      Examples:
+        * rake katello:cv_diff CONTENT_VIEW=my_super_cv VERSION1=13.0 VERSION2=14.1
+        * rake katello:cv_diff CONTENT_VIEW=some_cv
+
+      NOTE:
+        If no CV versions are given, the 2 latest versions of CONTENT_VIEW will be compared.
+        If only VERSION1 is given, the latest version of CONTENT_VIEW will be compared against VERSION1.
+
+  DESC
+  ## phess on 2020-10-19: everything below this is just a copy of sync_capules_selective.rake and needs to be actually written.
+  #
+  #### This works:
+  #
+  # cvv1 = Katello::ContentView.find( ID_OF_CVV_1 )  <=== grab this ID with hammer
+  # cvv2 = Katello::ContentView.find( ID_OF_CVV_2 )  <=== grab this ID with hammer
+  #
+  # pkgs1 = cvv1.packages.pluck(:filename)
+  # pkgs2 = cvv2.packages.pluck(:filename)
+  #
+  # Filenames in pkgs2 that are not in pkgs1:
+  # pkgs2.each {|pkg| puts pkg unless pkgs1.includes?(pkg) }
+  #
+  #  BOOM. :-)
+  #
+  #
+  #
+  #
+  #
+  task :cv_diff => ["environment", "check_ping"] do
+    capsule_id = ENV['CAPSULE_ID']
+    env = ENV['LIFECYCLE_ENVIRONMENT']
+    content_view = ENV['CONTENT_VIEW']
+    repository = ENV['REPOSITORY']
+    verbose = ENV['VERBOSE']
+    User.current = User.anonymous_api_admin
+
+    if capsule_id
+      capsule = SmartProxy.find(capsule_id)
+      puts "Syncing individual repos to capsule #{capsule.name}" if verbose == "true"
+    else
+      puts "ERROR: no CAPSULE_ID given. I need a CAPSULE_ID. Run ``rake -D katello:sync_capsule_selective'' to read about required and optional variables."
+      exit 3
+    end
+    
+    options = {}
+    if env
+      # Look up by name first, then by ID if name doesn't work
+      lce = Katello::KTEnvironment.find_by(:name => env)
+      unless lce
+        lce = Katello::KTEnvironment.find(env.to_i)
+      end
+      options[:environment_id] = lce.id
+    end
+
+    if content_view
+      # Look up by name first, then label, then ID
+      cv = Katello::ContentView.find_by(:name => content_view)
+      unless cv
+        cv = Katello::ContentView.find_by(:label => content_view)
+        unless cv
+          cv = Katello::ContentView.find(content_view.to_i)
+        end
+      end
+      options[:content_view_id] = cv.id
+    end
+
+    if repository
+      # Look up by numeric ID (Katello) then by pulp_id (UUID)
+      repo = Katello::Repository.find(repository.to_i)
+      unless repo
+        repo = Katello::Repository.find_by(:pulp_id => repository)
+      end
+      options[:repository_id] = repo.id
+    end
+
+    if verbose == "true"
+      puts "Will now sync capsule #{capsule.name} with these parameters:"
+      puts "  capsule.......: #{capsule}"
+      puts "  environment...: #{lce}"
+      puts "  content_view..: #{cv}"
+      puts "  repository....: #{repo}"
+      puts " **********"
+      puts " ** NOTE ** If the given environment or content_view or repository is not assigned to this capsule,"
+      puts " **      ** then nothing will be synced to this capsule."
+      puts " **      **"
+      puts " **      ** The same applies in case e.g. the chosen Content View is not published to the chosen"
+      puts " **      ** Lifecycle Environment."
+      puts " **********"
+    end
+    task = ForemanTasks.async_task(::Actions::Katello::CapsuleContent::Sync, capsule, options)
+  end
+end

--- a/cv_diff.rake
+++ b/cv_diff.rake
@@ -2,76 +2,186 @@ namespace :katello do
   desc <<-DESC.strip_heredoc
     Calculates and shows the difference (in terms of package contents) between two versions of the same Content View.
 
-      Required parameters:
-        * CONTENT_VIEW          : name or label or numeric ID of the Content View to examine
+      Parameters:
 
-      Optional:
-        * VERSION1              : CV version number (e.g. 14.0) or numeric ID (e.g. 523) of the first CV version to compare
-        * VERSION2              : CV version number (e.g. 14.0) or numeric ID (e.g. 523) of the second CV version to compare
+          * LEFT=CV:version  : Content View and version identifiers.
+                             : CV can be either a name or label or numerical ID of a Content View.
+                             : Omitting the version is the same as specifying the latest version of this Content View.
+                             : Version is specified as major.minor. See examples below.
+                             : Examples:
+                             :   LEFT="This nice CV"  -- latest version of a Content View named "This nice CV"
+                             :   LEFT="this_nice_cv"  -- latest version of a Content View named or labeled "this_nice_cv"
+                             :   LEFT="This nice CV:15.0"  -- version 15.0 of "This nice CV"
+                             :   LEFT="this_nice_cv:15.0"  -- version 15.0 of "this_nice_cv"
+                             :   LEFT="45"       -- latest version of Content View ID 45
+                             :   LEFT="45:15.0"  -- version 15.0 of Content View ID 45
+
+          * RIGHT=CV:version  : Content View and version identifiers.
+                              : Same conditions as LEFT, with a single exception:
+                              :   RIGHT=version (i.e. omitting the CV) will consider it to be the same Content View as LEFT.
+                              :   Omitting the RIGHT argument altogether will consider this to be the second-latest version of LEFT.
+                              : Examples:
+                              :   RIGHT="Other nice CV"  -- will compare LEFT to the latest version of "Other nice CV"
+                              :   RIGHT="other_nice_cv"  -- will compare LEFT to the latest version of "other_nice_cv"
+                              :   RIGHT="Other nice CV:31.0"  -- will compare LEFT to version 31.0 of "Other nice CV"
+                              :   RIGHT="other_nice_cv:31.0"  -- will compare LEFT to version 31.0 of "other_nice_cv"
+                              :   RIGHT="67"  -- will compare LEFT to the latest version of Content View ID 67
+                              :   RIGHT="45:31.0"  -- will compare LEFT to version 31.0 of Content View ID 67
+                              :   <RIGHT is omitted>  -- will compare LEFT to the second-latest version of LEFT
+
+
+        Global paramenter:
+
+        * VERBOSE               : Print verbose information.
 
       Examples:
-        * rake katello:cv_diff CONTENT_VIEW=my_super_cv VERSION1=13.0 VERSION2=14.1
-        * rake katello:cv_diff CONTENT_VIEW=some_cv
+        * rake katello:cv_diff LEFT="This nice CV:15.0"
+            (will diff version 15.0 and the latest version of "This nice CV")
 
-      NOTE:
-        If no CV versions are given, the 2 latest versions of CONTENT_VIEW will be compared.
-        If only VERSION1 is given, the latest version of CONTENT_VIEW will be compared against VERSION1.
+        * rake katello:cv_diff LEFT="this_nice_cv" RIGHT="Other CV"
+            (will diff the latest version of "this_nice_cv" to the latest version of "Other CV".)
+
+        * rake katello:cv_diff LEFT=14
+            (will diff the two latest versions of CV ID 14.)
+
+        * rake katello:cv_diff LEFT="some cv:3.2" RIGHT="another cv:5.1"
+            (will diff version 3.2 of "some cv" to version 5.1 of "another cv")
 
   DESC
   task :cv_diff => ["environment", "check_ping"] do
-    cv_id = ENV['CONTENT_VIEW']
-    versions = ENV['VERSIONS']
+    left_cv_spec = ENV['LEFT']
+    right_cv_spec = ENV['RIGHT']
     verbose = ENV['VERBOSE']
     User.current = User.anonymous_api_admin
 
-    cv = Katello::ContentView.find(cv_id)
-    cv_versions = versions.split(',', 2)
-    cv1 = cv.versions.find(cv_versions.first.to_i)
-    cv2 = cv.versions.find(cv_versions.last.to_i)
+    is_verbose = verbose == "true"
+
+    left_name_and_version = left_cv_spec.split(':')
+    if left_name_and_version.count == 2
+      # we have name:version
+      left_name, left_version = left_name_and_version
+    elsif left_name_and_version.count > 2
+      # cv name contains colon. Leave only the last element out as version
+      left_version = left_name_and_version.pop
+      left_name = left_name_and_version.join(':')
+    elsif left_name_and_version.count == 1
+      # cv has a name only
+      left_name = left_name_and_version.first
+      left_version = ""  # leave this blank as we'll use it when no RIGHT is specified. ;-)
+    end
+
+    if right_cv_spec
+      right_name_and_version = right_cv_spec.split(':')
+      if right_name_and_version.count == 2
+        # we have name:version
+        right_name, right_version = right_name_and_version
+      elsif right_name_and_version.count > 2
+        # cv name contains colon. Leave only the last element out as version
+        right_version = right_name_and_version.pop
+        right_name = right_name_and_version.join(':')
+      elsif right_name_and_version.count == 1
+        # cv has a name only OR a version only
+        # checking if it's a version like 4.0 (very common) or 567.9876 (unlikely but possible)
+        if right_name_and_version.first.match(/[1-9]\d*\.\d+/)
+          right_name = left_name
+          right_version= right_name_and_version.first
+        else
+          right_name = right_name_and_version.first
+          right_version = ""
+        end
+      end
+    else
+      # RIGHT was omitted so consider it to be the same CV as LEFT and the version is empty
+      right_name = ""
+      right_version = ""
+    end
+    
+    # Looking up LEFT
+    # Find the CV
+    results = [ "id", "name", "label" ].map {|key| Katello::ContentView.find_by(key => left_name)}.find(&:itself)
+    begin
+      left_cv = results
+    rescue StandardError
+      puts "** ERROR ** No Content View found matching #{cv_left_spec} in either ID, name, or label fields. Aborting."
+      exit 1
+    end
+    
+    # Find the CVV
+    if left_version.empty?
+      left_cvv = left_cv.versions.last
+    else
+      left_version_major, left_version_minor = left_version.split('.')
+      left_cvv = left_cv.versions.find_by(:major => left_version_major, :minor => left_version_minor)
+    end
+
+    # Look up RIGHT
+    if right_name.empty?
+      right_cv = left_cv
+      if right_version.empty?
+        # Assume latest version unless left_cvv is the latest version.
+        if left_cvv == right_cv.versions.last
+          right_cvv = right_cv.versions[-2]
+        else
+          right_cvv = right_cv.versions.last
+        end
+      else
+        # Find major and minor from LEFT CV
+        right_version_major, right_version_minor = right_version.split('.')
+        right_cvv = left_cv.versions.find_by(:major => right_version_major, :minor => right_version_minor)
+      end
+    else
+      results = [ "id", "name", "label" ].map {|key| Katello::ContentView.find_by(key => right_name)}.find(&:itself)
+      right_cv = results
+      if right_version.empty?
+        right_cvv = right_cv.versions.last
+      else
+        # Find major and minor for RIGHT CVV
+        right_version_major, right_version_minor = right_version.split('.')
+        right_cvv = right_cv.versions.find_by(:major => right_version_major, :minor => right_version_minor)
+      end
+    end
+
+    cv1 = {
+      "obj" => left_cvv,
+      "parentname" => left_cvv.content_view.name,
+      "version" => "#{left_cvv.major}.#{left_cvv.minor}",
+      "displayname" => left_cvv.content_view.name + ":" + "#{left_cvv.major}.#{left_cvv.minor}",
+      "cvpkgs" => left_cvv.packages.sort
+    }
+    cv2 = {
+      "obj" => right_cvv,
+      "parentname" => right_cvv.content_view.name,
+      "version" => "#{right_cvv.major}.#{right_cvv.minor}",
+      "displayname" => right_cvv.content_view.name + ":" + "#{right_cvv.major}.#{right_cvv.minor}",
+      "cvpkgs" => right_cvv.packages.sort,
+      "othercv" => cv1
+    }
+    cv1["othercv"] = cv2
+    
     $allcvs = [ cv1, cv2 ]
 
-    def cvmajmin(cvversion)
-      return "#{cvversion.major}.#{cvversion.minor}"
-    end
-
-    def cvname(cvversion)
-      return cvversion.content_view.name
-    end
-
-    def cvvname(cvversion)
-      return cvname(cvversion) + ":" + cvmajmin(cvversion)
-    end
-
-    def cvpkgs(cvversion)
-      return cvversion.packages
-    end
-
-    def othercv(cvversion)
-      # Find who the "other" CV is
-      othercv = ($allcvs - [ cvversion ]).first
-      return othercv
-    end
-
     def cvexclusivepkgs(cvversion)
-      theother = othercv(cvversion)
-      return cvversion.packages - theother.packages
+      return cvversion["exclusivepkgs"] if cvversion["exclusivepkgs"]
+      theother = cvversion["othercv"]
+      cvversion["exclusivepkgs"] = cvversion["cvpkgs"] - theother["cvpkgs"]
+      return cvversion["exclusivepkgs"]
     end
 
-    puts "Diffing Content View '#{cv.name}' versions #{cvmajmin(cv1)} and #{cvmajmin(cv2)}"
-    puts "Package counts are #{cvpkgs(cv1).count} and #{cvpkgs(cv2).count}."
+    puts "Diffing Content Views\n\t'#{cv1["parentname"]}' version #{cv1["version"]} (#{cv1["cvpkgs"].count} pkgs)\n\tto\n\t'#{cv2["parentname"]}' version #{cv2["version"]} (#{cv2["cvpkgs"].count} pkgs)"
 
     puts ""
-    [ cv1, cv2 ].each do
+    $allcvs.each do
       |onecv|
-      puts "#{cvvname(onecv)} has #{cvexclusivepkgs(onecv).count} exclusive packages that the other Content View Version does not."
+      puts "#{onecv["displayname"]} has #{cvexclusivepkgs(onecv).count} exclusive packages that the #{onecv["othercv"]["displayname"]} does not."
     end
 
     puts ""
-    [ cv1, cv2 ].each do
+    $allcvs.each do
       |onecv|
-      puts "List of packages exclusive to #{cvvname(onecv)}:"
-      cvexclusivepkgs(onecv).each_with_index do |pkg, idx|
-        puts "#{idx+1}:\t#{pkg.nvra}"
+      puts "List of packages exclusive to #{onecv["displayname"]}:"
+      cvexclusivepkgs(onecv).pluck(:nvra).sort.each_with_index do
+        |nvra, idx|
+        puts "#{idx+1}:\t#{nvra}"
       end
       puts "------"
     end


### PR DESCRIPTION
cv_diff.rake compares two Content Views (actually two Content View Versions) in terms of contents. Initially supported objects for comparison are RPMs, repos, and errata. That is, one can compare which errata are included in the two CVs, or which RPMs, or which repositories.

Specifically errata diffing is especially useful when troubleshooting CV filters.